### PR TITLE
Fix issue # 519: Innaccurate OpenAPI schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -146,6 +146,8 @@ paths:
           description: validation errors
         '404':
           description: not found
+        '409':
+          description: conflict
         '412':
           description: precondition failed
   /jobs:
@@ -273,6 +275,8 @@ paths:
           description: validation errors
         '404':
           description: not found
+        '409':
+          description: conflict
         '412':
           description: precondition failed
   /jobs/{id}/status:
@@ -363,6 +367,8 @@ paths:
           description: validation errors
         '404':
           description: not found
+        '409':
+          description: conflict
   /health:
     get:
       summary: Queries health-related information
@@ -423,17 +429,14 @@ components:
         name:
           type: string
           description: unique job name
-          readOnly: true
           example: 'My Task #1'
         state:
           type: string
-          readOnly: true
           enum:
             - enabled
             - disabled
         schedule:
           type: string
-          readOnly: true
           example: '@every 1h'
     JobDefinition:
       allOf:


### PR DESCRIPTION
**Removed readOnly attribute for JobItem component**
This allows to display and generate a correct API call for `POST /jobs`.

**Added 409 HTTP error on delete methods**
This error is raised when someone tries to delete a job that is currently running, so it should be pointed out on API definiton.