### PR TITLE
chore: update CA root certificates to prevent the "Certificate Signed by Unknown Authority" error.

### DIFF
--- a/misc/docker/Dockerfile
+++ b/misc/docker/Dockerfile
@@ -11,6 +11,9 @@ RUN set -ex \
     && CGO_ENABLED=0 go build -ldflags '-s -w -extldflags "-static"' \
     && upx -q /src/scheduler
 
+RUN apk --no-cache add ca-certificates
+RUN update-ca-certificates
+
 FROM node:alpine as n
 
 ADD . /src
@@ -26,6 +29,7 @@ FROM scratch
 LABEL maintainer="Andriy Kornatskyy <andriy.kornatskyy@live.com>"
 
 COPY --from=g /src/scheduler /
+COPY --from=g /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=n /src/static /static
 COPY --from=n /etc/passwd /etc/passwd
 


### PR DESCRIPTION
Update Dockerfile - updates CA root certificates to prevent the "Certificate Signed by Unknown Authority" error